### PR TITLE
Keystone Feedback and Pokemon in Any Slot of Triple/Double Battles Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.3.4
+- Pokémon can now be in any slot within Double and Triple PVP Battles.
+- Right-clicking the keystone will now give feedback based on active Pokémon eligibility on Mega Evolution.
+    - Right-clicking the keystone with an eligible active Pokémon will now give feedback on mega evolving next turn when the player chooses a move.
+    - You can right-click again to toggle off the mega evolution choice. 
+    - The keystone will gain an enchantment glint when toggled on.
+
 # 1.3.3
 - Fixed Charizard and Mewtwo abilities not being set after mega evolving
 - Made mega evolution possible in double-triple pvp formats. However ! : 

--- a/common/src/main/java/com/selfdot/cobblemonmegas/common/CobblemonMegas.java
+++ b/common/src/main/java/com/selfdot/cobblemonmegas/common/CobblemonMegas.java
@@ -9,6 +9,7 @@ import com.cobblemon.mod.common.api.pokemon.PokemonSpecies;
 import com.cobblemon.mod.common.api.pokemon.feature.FlagSpeciesFeatureProvider;
 import com.cobblemon.mod.common.api.pokemon.feature.SpeciesFeatures;
 import com.cobblemon.mod.common.api.pokemon.helditem.HeldItemProvider;
+import com.cobblemon.mod.common.battles.ActiveBattlePokemon;
 import com.cobblemon.mod.common.pokemon.Species;
 import com.selfdot.cobblemonmegas.common.command.CommandTree;
 import com.selfdot.cobblemonmegas.common.command.permissions.PermissionValidator;
@@ -56,6 +57,7 @@ public class CobblemonMegas extends DisableableMod {
     @Setter
     private PermissionValidator permissionValidator = new VanillaPermissionValidator();
     private final Set<UUID> TO_MEGA_EVOLVE_THIS_TURN = new HashSet<>();
+    private final Set<ActiveBattlePokemon> MEGA_EVOLVE_TARGET = new HashSet<>();
     private final Set<UUID> HAS_MEGA_EVOLVED_THIS_BATTLE = new HashSet<>();
     @Getter
     private final ConcurrentHashMap<UUID, Ability> originalAbilities = new ConcurrentHashMap<>();
@@ -70,6 +72,8 @@ public class CobblemonMegas extends DisableableMod {
     public Set<UUID> getHasMegaEvolvedThisBattle() {
         return HAS_MEGA_EVOLVED_THIS_BATTLE;
     }
+
+    public Set<ActiveBattlePokemon> getMegaEvolveTarget(){return MEGA_EVOLVE_TARGET; }
 
     public void onInitialize() {
         config = new Config(this);

--- a/common/src/main/java/com/selfdot/cobblemonmegas/common/mixin/BattleActorMixin.java
+++ b/common/src/main/java/com/selfdot/cobblemonmegas/common/mixin/BattleActorMixin.java
@@ -30,13 +30,19 @@ public abstract class BattleActorMixin {
         UUID uuid = getUuid();
         if (CobblemonMegas.getInstance().getToMegaEvolveThisTurn().remove(uuid)) {
             if (responses.isEmpty()) return;
-            if (!(responses.getFirst() instanceof MoveActionResponse moveActionResponse)) return;
-            if (activePokemon.isEmpty()) return;
-            BattlePokemon battlePokemon = activePokemon.getFirst().getBattlePokemon();
-            if (battlePokemon == null) return;
-            String megaStone = battlePokemon.getHeldItemManager().showdownId(battlePokemon);
-            if (megaStone == null) return;
-            moveActionResponse.setGimmickID(ShowdownMoveset.Gimmick.MEGA_EVOLUTION.getId());
+            for(int response=0;response<responses.size();response++){
+                if (!(responses.get(response) instanceof MoveActionResponse moveActionResponse)) continue;
+                if (CobblemonMegas.getInstance().getMegaEvolveTarget().remove(activePokemon.get(response))) {
+                    if (activePokemon.isEmpty()) continue;
+                    BattlePokemon battlePokemon = activePokemon.get(response).getBattlePokemon();
+                    if (battlePokemon == null) continue;
+                    String megaStone = battlePokemon.getHeldItemManager().showdownId(battlePokemon);
+                    if (megaStone == null) continue;
+                    moveActionResponse.setGimmickID(ShowdownMoveset.Gimmick.MEGA_EVOLUTION.getId());
+                }
+
+            }
+
         }
     }
 

--- a/common/src/main/java/com/selfdot/cobblemonmegas/common/mixin/ItemMixin.java
+++ b/common/src/main/java/com/selfdot/cobblemonmegas/common/mixin/ItemMixin.java
@@ -1,5 +1,9 @@
 package com.selfdot.cobblemonmegas.common.mixin;
 
+import com.cobblemon.mod.common.api.battles.model.PokemonBattle;
+import com.cobblemon.mod.common.api.battles.model.actor.BattleActor;
+import com.cobblemon.mod.common.battles.ActiveBattlePokemon;
+import com.cobblemon.mod.common.battles.BattleRegistry;
 import com.selfdot.cobblemonmegas.common.DataKeys;
 import com.selfdot.cobblemonmegas.common.util.MegaUtils;
 import com.selfdot.cobblemonmegas.common.util.NbtUtils;
@@ -17,6 +21,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import java.util.List;
+
 @Mixin(Item.class)
 public abstract class ItemMixin {
 
@@ -29,7 +35,20 @@ public abstract class ItemMixin {
         NbtCompound nbt = NbtUtils.getNbt(itemStack, "");
         if (nbt.isEmpty() || !nbt.contains(DataKeys.NBT_KEY_KEY_STONE)) return;
         if (!nbt.getBoolean(DataKeys.NBT_KEY_KEY_STONE)) return;
-        MegaUtils.attemptMegaEvolveInBattle(player, false);
+
+        PokemonBattle battle = BattleRegistry.INSTANCE.getBattleByParticipatingPlayer(player);
+        if (battle == null) return;
+        BattleActor playerBattleActor = battle.getActor(player);
+        if (playerBattleActor == null) return;
+        List<ActiveBattlePokemon> activeBattlePokemon = playerBattleActor.getActivePokemon();
+        if (activeBattlePokemon.isEmpty()) return;
+        int finalPos = 0;
+        String reasonCannotMegaEvolve = null;
+        for(int pos=0;pos < playerBattleActor.getActivePokemon().size(); pos++){
+            reasonCannotMegaEvolve = MegaUtils.reasonCannotMegaEvolve(player, activeBattlePokemon.get(pos).getBattlePokemon().getEffectedPokemon(),pos);
+            if (reasonCannotMegaEvolve == null){finalPos = pos;}
+        }
+        MegaUtils.attemptMegaEvolveInBattle(player, true,finalPos);
         cir.setReturnValue(TypedActionResult.consume(itemStack));
     }
 


### PR DESCRIPTION
# KeyStone Feedback and Mega-able Pokémon In Any Slot of Triple & Double Battles Fix:

Heyo! This is my attempt to fixing the issue you had with Mega-eligible Pokémon only being able to mega evolve in certain slots of triple and double battles. They should be able to mega evolve in any slot now! The button unfortunately still does not work for the two battle formats, but the keystone (aka mega bracelet) now gives feedback when the player right clicks it. No more having to hope you clicked the item!

Check the changelog.md for more details and check out the video below!

[![Watch the video](https://img.youtube.com/vi/1fJ7WffI2q4/maxresdefault.jpg)](https://youtu.be/1fJ7WffI2q4)